### PR TITLE
[17.0][IMP] Added colors to kanban view for ready to ship pickings

### DIFF
--- a/delivery_common/__manifest__.py
+++ b/delivery_common/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Delivery Common",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "summary": """ Base module for Impress Delivery Connectors """,
     "author": "Cédric Paradis",
     "website": "https://github.com/Impress-Foods/impress-odoo",

--- a/delivery_common/models/stock_picking.py
+++ b/delivery_common/models/stock_picking.py
@@ -19,6 +19,8 @@ class StockPicking(models.Model):
         store=True,
     )
 
+    ready_to_ship = fields.Boolean(copy=False, compute="_compute_ready_to_ship")
+
     @api.depends("sale_id", "sale_id.note", "sale_id.delivery_message")
     def _compute_delivery_instructions(self) -> None:
         for picking in self:
@@ -36,6 +38,11 @@ class StockPicking(models.Model):
                 elif picking.sale_id.delivery_message:
                     note = picking.sale_id.delivery_message
             picking.delivery_instructions = note
+
+    @api.depends("move_line_ids", "move_line_ids.picked")
+    def _compute_ready_to_ship(self):
+        for record in self:
+            record.ready_to_ship = all(record.move_line_ids.mapped("picked"))
 
     def _get_autoprint_report_actions(self) -> list[dict]:
         report_actions: list[dict] = super()._get_autoprint_report_actions()

--- a/delivery_common/views/stock_picking_views.xml
+++ b/delivery_common/views/stock_picking_views.xml
@@ -25,8 +25,16 @@
         <field name="inherit_id" ref="stock.stock_picking_kanban" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='picking_properties']" position="after">
-                <span> &amp;nbsp;-&amp;nbsp;</span>
                 <field name="carrier_id" />
+                <span t-if="record.carrier_id.value"> &amp;nbsp;-&amp;nbsp;</span>
+            </xpath>
+            <xpath expr="//t[1]" position="inside">
+                <field name="ready_to_ship" invisible="1" />
+            </xpath>
+            <xpath expr="//t/div[1]" position="attributes">
+                <attribute
+                    name="t-attf-class"
+                >{{ record.ready_to_ship.raw_value ? 'oe_kanban_color_10' :  'oe_kanban_color_1' }} oe_kanban_card oe_kanban_global_click</attribute>
             </xpath>
         </field>
     </record>

--- a/impress_barcode/__manifest__.py
+++ b/impress_barcode/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    "name": "impress_barcode",
+    "name": "Impress Barcode Tweaks",
     "summary": """
         Customizations to barcode app
     """,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `ready_to_ship` computed field to track picking completion status

- Implemented kanban view color coding based on ready-to-ship status

- Improved carrier field display with conditional spacing in kanban

- Updated module metadata and version numbers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stock Picking Model"] -->|"Add computed field"| B["ready_to_ship field"]
  B -->|"Based on move lines"| C["All lines picked?"]
  C -->|"True"| D["Green color - oe_kanban_color_10"]
  C -->|"False"| E["Red color - oe_kanban_color_1"]
  D -->|"Display in"| F["Kanban View"]
  E -->|"Display in"| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__manifest__.py</strong><dd><code>Version bump for delivery common module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

delivery_common/__manifest__.py

- Bumped version from 17.0.1.0.0 to 17.0.1.0.1


</details>


  </td>
  <td><a href="https://github.com/Impress-Foods/impress-odoo/pull/178/files#diff-fb84df8f8526dca8e5608302b450920d166bcf8f4fcc2715d8e491a282c818da">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__manifest__.py</strong><dd><code>Improve module name clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

impress_barcode/__manifest__.py

<ul><li>Updated module name from "impress_barcode" to "Impress Barcode Tweaks"</ul>


</details>


  </td>
  <td><a href="https://github.com/Impress-Foods/impress-odoo/pull/178/files#diff-6847353671362d76404c277de99f8befa8db369865b346cec35378361ae14ab8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stock_picking.py</strong><dd><code>Add ready-to-ship computed field to stock picking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

delivery_common/models/stock_picking.py

<ul><li>Added <code>ready_to_ship</code> Boolean computed field with <code>copy=False</code> flag<br> <li> Implemented <code>_compute_ready_to_ship()</code> method that checks if all move <br>lines are picked<br> <li> Field depends on <code>move_line_ids</code> for automatic recomputation</ul>


</details>


  </td>
  <td><a href="https://github.com/Impress-Foods/impress-odoo/pull/178/files#diff-af8c0045b1231d051367f6e210d7cb2bbc7d7d865a31c575bc364eea922f30ad">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stock_picking_views.xml</strong><dd><code>Add kanban color coding based on ready-to-ship status</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

delivery_common/views/stock_picking_views.xml

<ul><li>Added <code>ready_to_ship</code> field to kanban view with invisible attribute<br> <li> Implemented dynamic CSS class binding based on <code>ready_to_ship</code> status<br> <li> Applied color coding: green (oe_kanban_color_10) when ready, red <br>(oe_kanban_color_1) otherwise<br> <li> Fixed carrier field display with conditional spacing separator</ul>


</details>


  </td>
  <td><a href="https://github.com/Impress-Foods/impress-odoo/pull/178/files#diff-073e71f6fcc2b8b054d0e4fe77d18f3dc094620066f8ca8bc387adf027fe033b">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

