### PR TITLE
[17.0][FIX] Added small fix for minimum_shelf_life display

### DIFF
--- a/impress_barcode/static/src/components/line.xml
+++ b/impress_barcode/static/src/components/line.xml
@@ -2,6 +2,21 @@
 <templates xml:space="preserve">
 
     <t
+        t-name="impress_barcode.add_image"
+        t-inherit="stock_barcode.LineComponent"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath expr="//div[hasclass('o_barcode_line_details')]" position='before'>
+            <div class="d-flex flex-row flex-nowrap px-4">
+                <img
+                    t-attf-src="/web/image?model=product.product&amp;id={{props.line.product_id.id}}&amp;field=image_128"
+                />
+            </div>
+        </xpath>
+
+    </t>
+    <t
         t-name="stock_barcode.lineQuantity_add_total_demand"
         t-inherit="stock_barcode.LineQuantity"
         t-inherit-mode="extension"

--- a/impress_stock_customizations/__manifest__.py
+++ b/impress_stock_customizations/__manifest__.py
@@ -16,5 +16,6 @@
         "reports/online_sale_labels.xml",
         "views/stock_lot_views.xml",
         "reports/stock_picking_document_views.xml",
+        "reports/online_sale_labels.xml",
     ],
 }

--- a/impress_stock_customizations/reports/impress_stock_customizations_labels.xml
+++ b/impress_stock_customizations/reports/impress_stock_customizations_labels.xml
@@ -18,51 +18,43 @@
                     <t
                         t-foreach="move.move_line_ids"
                         t-as="line"
-                    > ^XACI28 ^FX Border Definitions
-                        ^FX From field ^FO2,4 ^GB254,203,2 ^FS ^FX To field ^FO254,4 ^GB558,203,2
-                        ^FS ^FX Postal Code field ^FO2,203 ^GB508,206,2 ^FS ^FX Carrier info field
-                        ^FO508,203 ^GB304,206,2 ^FS ^FX Product info field ^FO2,409 ^GB812,406,2 ^FS
-                        ^FX MAN Segment field ^FO2,815 ^GB812,403,2 ^FS ^FX Data definitions ^FX
-                        From field ^FO10,16 ^A0N,26,26^FB200,1^FDFrom/DE: ^FS ^FO20,50
-                        ^A0N,26,26^FB225,5^FDImpress Foods Inc. 1910 rue du Sanctuaire, Quebec, QC
-                        G1E 3L2 ^FS ^FX To field ^FO264,16 ^A0N,26,26^FB200,1^FDTo/A: ^FS ^FO284,50
-                        ^A0N,26,26^FB300,5^FD<t t-out="contact_name" /> . <t
-                            t-out="contact_street"
-                        /> , <t t-out="contact_city" /> , <t t-out="contact_state" />
-                    <t t-out="contact_zip" /> ^FS ^FX Postal code field ^FO10,213
-                        ^A0N,26,26^FB500,1^FDShip to Postal Code: ^FS ^FO15,243
-                        ^A0N,26,26^FB500,1^FD(420)<t
+                    > ^XACI28 ^FX Border Definitions ^FX From field ^FO2,4 ^GB254,203,2 ^FS ^FX To field ^FO254,4 ^GB558,203,2 ^FS ^FX Postal Code field ^FO2,203 ^GB508,206,2 ^FS ^FX
+                        Carrier info field ^FO508,203 ^GB304,206,2 ^FS ^FX Product info field ^FO2,409 ^GB812,406,2 ^FS ^FX MAN Segment field ^FO2,815 ^GB812,403,2 ^FS ^FX Data definitions ^FX From
+                        field ^FO10,16 ^A0N,26,26^FB200,1^FDFrom/DE: ^FS ^FO20,50 ^A0N,26,26^FB225,5^FDImpress Foods Inc. 1910 rue du Sanctuaire, Quebec, QC G1E 3L2 ^FS ^FX To field ^FO264,16
+                        ^A0N,26,26^FB200,1^FDTo/A: ^FS ^FO284,50 ^A0N,26,26^FB300,5^FD<t
+                            t-out="contact_name"
+                        /> . <t t-out="contact_street" /> , <t
+                            t-out="contact_city"
+                        /> , <t t-out="contact_state" />
+                    <t
                             t-out="contact_zip"
-                        /> ^FS ^FO90,288
-                        ^BCN,100,N,N,Y^FD420<t
+                        /> ^FS ^FX Postal code field ^FO10,213 ^A0N,26,26^FB500,1^FDShip to
+                        Postal Code: ^FS ^FO15,243 ^A0N,26,26^FB500,1^FD(420)<t
                             t-out="contact_zip"
-                        /> ^FS ^FX Carrier Field
-                        ^FO518,213 ^A0N,26,26^FB500,1^FDCarrier: ^FS ^FO518,243
-                        ^A0N,26,26^FB500,1^FD<t t-out="carrier" /> ^FS ^FO518,273
-                        ^A0N,26,26^FB500,1^FDPro: 12345 ^FS ^FO518,303 ^A0N,26,26^FB500,1^FDB/L:
-                        123456789 ^FS ^FX Product Field ^FO20,439 ^A0N,40,40^FB500,1^FDPO: <t
+                        /> ^FS ^FO90,288 ^BCN,100,N,N,Y^FD420<t
+                            t-out="contact_zip"
+                        /> ^FS ^FX Carrier Field ^FO518,213 ^A0N,26,26^FB500,1^FDCarrier: ^FS ^FO518,243 ^A0N,26,26^FB500,1^FD<t
+                            t-out="carrier"
+                        /> ^FS ^FO518,273
+                        ^A0N,26,26^FB500,1^FDPro: 12345 ^FS ^FO518,303 ^A0N,26,26^FB500,1^FDB/L: 123456789 ^FS ^FX Product Field ^FO20,439 ^A0N,40,40^FB500,1^FDPO: <t
                             t-out="PO"
                         /> ^FS ^FO20,489 ^A0N,40,40^FB500,1^FDGTIN: <t
                             t-out="line.product_barcode"
                         /> ^FS ^FO500,489 ^A0N,40,40^FB500,1^FDLOT: <t
                             t-out="line.lot_id.display_name"
-                        /> ^FS ^FO20,539 ^A0N,40,40^FB800,2^FDItem
-                        Description: <t
+                        /> ^FS ^FO20,539 ^A0N,40,40^FB800,2^FDItem Description: <t
                             t-raw="line.product_id.display_name"
-                        /> ^FS ^FO130,639
-                        ^A0N,40,40^FB800,1^FDCase QTY: <t
+                        /> ^FS ^FO130,639 ^A0N,40,40^FB800,1^FDCase QTY: <t
                             t-out="line.quantity"
-                        /> ^FS ^FO130,689
-                        ^A0N,40,40^FB800,1^FDProduct Net Weight (KG): ^FS ^FO130,739
-                        ^A0N,40,40^FB800,1^FDCode Date: <t
+                        /> ^FS ^FO130,689 ^A0N,40,40^FB800,1^FDProduct Net Weight (KG): ^FS ^FO130,739 ^A0N,40,40^FB800,1^FDCode Date: <t
                             t-esc="line.lot_id.use_date.strftime('%Y-%m-%d')"
-                        /> ^FS ^FX MAN Segment
-                        ^FO10,822 ^A0N,26,26^FB500,1^FDMAN Segment (SSCC-18): ^FS ^FO110,900
+                        /> ^FS ^FX MAN Segment ^FO10,822 ^A0N,26,26^FB500,1^FDMAN Segment (SSCC-18): ^FS ^FO110,900
                         ^BCN,225,Y,Y,Y,A^FD(00)003001234000000001 ^XZ </t>
                 </t>
             </t>
         </t>
     </template>
+
     <record id="impress_stock_customizations_lot_label_zpl" model="ir.ui.view">
         <field name="name">impress.stock_customizations.lot_label.zpl</field>
         <field name="inherit_id" ref="stock.label_lot_template_view" />
@@ -97,14 +89,12 @@
                                     t-elif="lot['lot_record'].product_id.tracking == 'serial'"
                                     t-set="final_barcode"
                                     t-value="(final_barcode or '') + '21' + lot['name']"
-                                />
-                            ^FO425,150^BY3 ^BXN,8,200 ^FD<t
+                                /> ^FO425,150^BY3 ^BXN,8,200 ^FD<t
                                     t-out="final_barcode"
                                 /> ^FS </t>
         <t t-else="" name="code128_barcode"> ^FO100,150^BY3 ^BCN,100,Y,N,N ^FD<t
                                     t-out="lot['name']"
-                                /> ^FS </t>
-                                ^FO275,300 ^A0N,44,33^FDLN/SN: <t
+                                /> ^FS </t> ^FO275,300 ^A0N,44,33^FDLN/SN: <t
                                 t-out="lot['name']"
                             /> ^FS ^XZ </t>
                     </t>

--- a/impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml
+++ b/impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml
@@ -11,8 +11,10 @@
         <field name="inherit_id" ref="stock.report_delivery_document" />
         <field name="priority">50</field>
         <field name="arch" type="xml">
-            <xpath expr="//table[@name='stock_move_table']/tbody" position="after">
-            </xpath>
+            <xpath
+                expr="//table[@name='stock_move_table']/tbody"
+                position="after"
+            > </xpath>
         </field>
     </record>
 
@@ -20,8 +22,9 @@
         id="impress_stock_report_delivery_document_add_column_sums"
         model="ir.ui.view"
     >
-        <field name="name">
-            stock.report_delivery_document.impress.add_column_sums</field>
+        <field
+            name="name"
+        > stock.report_delivery_document.impress.add_column_sums</field>
         <field name="inherit_id" ref="stock.report_delivery_document" />
         <field name="priority">51</field>
         <field name="arch" type="xml">
@@ -98,13 +101,18 @@
         id="impress_stock_report_delivery_document_add_minimum_shelf_life"
         model="ir.ui.view"
     >
-        <field name="name">
-            stock.report_delivery_document.impress.add_minimum_shelf_life</field>
+        <field
+            name="name"
+        > stock.report_delivery_document.impress.add_minimum_shelf_life</field>
         <field name="inherit_id" ref="stock.report_delivery_document" />
         <field name="priority">51</field>
         <field name="arch" type="xml">
             <xpath expr="//*[@name='div_sched_date']" position="after">
-                <div class="col-auto" name="minimimum_shelf_life">
+                <div
+                    class="col-auto"
+                    name="minimimum_shelf_life"
+                    t-if="o.fields_get().get('x_minimum_shelf_life', False)"
+                >
                     <strong>Minimum shelf life:</strong>
                     <br />
                     <p>
@@ -192,8 +200,7 @@
                         </div>
                     </div>
                 </t>
-                <div class="row">
-                </div>
+                <div class="row"> </div>
                 <div class="pt-5">
                     <!-- This div ensures that the address is not cropped by the
                     header. -->
@@ -220,31 +227,23 @@
                 >
                     <div
                         class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center p-3 opacity-75 text-muted text-center"
-                    >
-                        (document barcode)
-                    </div>
+                    > (document barcode) </div>
                 </div>
             </xpath>
         </field>
     </record>
 
-    <!-- <record id="impress_stock_report_delivery_document_add_barcode" model="ir.ui.view">
-        <field name="name">stock.report_delivery_document.impress.add_barcode</field>
-        <field name="inherit_id" ref="stock.report_delivery_document" />
-        <field name="priority">53</field>
-        <field name="arch" type="xml">
-        </field>
-    </record> -->
     <record id="report_delivery_document_add_shelf_life" model="ir.ui.view">
         <field name="name">stock.report_delivery_document.impress.add_shelf_lift</field>
         <field name="inherit_id" ref="stock.report_delivery_document" />
         <field name="priority">53</field>
         <field name="arch" type="xml">
-             <!-- For state == done -->
+            <!-- For state == done -->
             <xpath expr="//th[@name='lot_serial']" position="after">
-                <th name="shelf_life_remaining" t-if="has_serial_number">
-                    Shelf life remaining
-                </th>
+                <th
+                    name="shelf_life_remaining"
+                    t-if="has_serial_number"
+                > Shelf life remaining </th>
             </xpath>
         </field>
     </record>
@@ -254,7 +253,9 @@
     >
         <xpath expr="//t[@name='move_line_lot']" position="after">
             <t t-if="has_serial_number" name="shelf_life_remaining">
-                <td><span t-field="move_line.lot_id.life_remaining" /></td>
+                <td>
+                    <span t-field="move_line.lot_id.life_remaining" />
+                </td>
             </t>
         </xpath>
     </template>

--- a/impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml
+++ b/impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml
@@ -247,6 +247,7 @@
             </xpath>
         </field>
     </record>
+
     <template
         id="stock_report_delivery_has_serial_move_line"
         inherit_id="stock.stock_report_delivery_has_serial_move_line"

--- a/impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml
+++ b/impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml
@@ -110,7 +110,7 @@
             <xpath expr="//*[@name='div_sched_date']" position="after">
                 <div
                     class="col-auto"
-                    name="minimimum_shelf_life"
+                    name="minimum_shelf_life"
                     t-if="o.fields_get().get('x_minimum_shelf_life', False)"
                 >
                     <strong>Minimum shelf life:</strong>

--- a/impress_stock_customizations/reports/online_sale_labels.xml
+++ b/impress_stock_customizations/reports/online_sale_labels.xml
@@ -2,33 +2,134 @@
 <odoo>
 
     <template id="report_online_sale_label">
-        <t t-foreach="docs" t-as="transfer">
-            ^XA^CI28
-            ^FO100,50
-            ^A0N,44,33^FDCommande: <t t-out="transfer.origin" />
-^FS
-            ^FO100,100
-            ^A0N,44,33^FDClient: <t t-out="transfer.partner_id.display_name" />
-^FS
+        <t
+            t-foreach="docs"
+            t-as="transfer"
+        > ^XA^CI28 ^FO100,50 ^A0N,44,33^FDCommande: <t
+                t-out="transfer.origin"
+            /> ^FS ^FO100,100 ^A0N,44,33^FDClient: <t
+                t-out="transfer.partner_id.display_name"
+            /> ^FS ^FO425,150^BY3 ^BXN,8,200 ^FD<t
+                t-out="transfer.origin"
+            /> ^FS ^XZ </t>
+    </template>
 
-            ^FO425,150^BY3
-            ^BXN,8,200
-            ^FD<t t-out="transfer.origin" />
-^FS
 
-            ^XZ
-</t>
-</template>
-<record id="action_report_online_sale_label" model="ir.actions.report">
-<field name="name">Online Sale Label</field>
-<field name="model">stock.picking</field>
-<field name="report_type">qweb-text</field>
-<field name="report_name">impress_stock_customizations.report_online_sale_label</field>
-<field name="report_file">impress_stock_customizations.report_online_sale_label</field>
-<field
+    <record id="action_report_online_sale_label" model="ir.actions.report">
+        <field name="name">Online Sale Label</field>
+        <field name="model">stock.picking</field>
+        <field name="report_type">qweb-text</field>
+        <field
+            name="report_name"
+        >impress_stock_customizations.report_online_sale_label</field>
+        <field
+            name="report_file"
+        >impress_stock_customizations.report_online_sale_label</field>
+        <field
             name="print_report_name"
         >'Online Sale Label - %s - %s' % (object.partner_id.name or '', object.origin)</field>
-<field name="binding_model_id" ref="stock.model_stock_picking" />
-<field name="binding_type">report</field>
-</record>
+        <field name="binding_model_id" ref="stock.model_stock_picking" />
+        <field name="binding_type">report</field>
+    </record>
+
+
+    <template id="zpl_online_sales_content_view">
+        <t t-translate="off">
+            <t name="start_label">
+                <t t-out="'^XA'" />
+                <t t-out="'^MMT'" />
+                <t t-out="'^PW800'" />
+                <t t-out="'^LL1200'" />
+                <t t-out="'^LS0'" />
+            </t>
+
+            <t name="order_package_info">
+                <t t-out="'^FO50,50^A0N,30,30^FD'" /> Order: <t
+                    t-out="picking.origin"
+                /> / <t t-out="str(package_index+1)" /> of <t
+                    t-out="str(package_total)"
+                /> <t t-out="'^FS'" />
+            </t>
+
+            <t name="separator_line_1">
+                <t t-out="'^FO40,100^GB720,2,2^FS'" />
+            </t>
+
+            <t name="content_header">
+                <t t-set="header_y" t-value="120" />
+                <t t-out="'^FO50,' + str(header_y) + '^A0N,30,30^FD'" />Product<t
+                    t-out="'^FS'"
+                />
+                <t t-out="'^FO400,' + str(header_y) + '^A0N,30,30^FD'" />Lot<t
+                    t-out="'^FS'"
+                />
+                <t t-out="'^FO650,' + str(header_y) + '^A0N,30,30^FD'" />Qty<t
+                    t-out="'^FS'"
+                />
+            </t>
+
+            <t name="separator_line_2">
+                <t t-out="'^FO40,160^GB720,2,2^FS'" />
+            </t>
+
+            <t name="package_content_details">
+                <t t-set="current_y" t-value="180" />
+                <t t-foreach="package.quant_ids" t-as="quant">
+                    <t
+                        t-out="'^FO50,' + str(current_y) + '^A0N,25,25^FD' + quant.product_id.display_name + '^FS'"
+                    />
+                    <t t-if="quant.lot_id">
+                        <t
+                            t-out="'^FO400,' + str(current_y) + '^A0N,25,25^FD' + quant.lot_id.name + '^FS'"
+                        />
+                    </t>
+                    <t
+                        t-out="'^FO650,' + str(current_y) + '^A0N,25,25^FD' + str(quant.quantity) + '^FS'"
+                    />
+                    <t t-set="current_y" t-value="current_y + 35" />
+                </t>
+            </t>
+
+            <t name="separator_line_3">
+                <t t-out="'^FO40,' + str(current_y + 10) + '^GB720,2,2^FS'" />
+            </t>
+
+            <t name="end_label">
+                <t t-out="'^XZ'" />
+            </t>
+        </t>
+    </template>
+
+    <template id="zpl_online_sales_content">
+        <t t-foreach="docs" t-as="o">
+            <t t-set="current_picking" t-value="o" />
+            <t t-foreach="o.move_line_ids.mapped('result_package_id')" t-as="package">
+                <t
+                    t-call="impress_stock_customizations.zpl_online_sales_content_view"
+                    t-lang="o._get_report_lang()"
+                >
+                    <t t-set="picking" t-value="current_picking" />
+                    <t t-set="package_index" t-value="package_index" />
+                    <t t-set="package_total" t-value="package_size" />
+                </t>
+            </t>
+        </t>
+    </template>
+
+    <record id="action_report_zpl_online_sales_content" model="ir.actions.report">
+        <field name="name">ZPL Online Sales Content</field>
+        <field name="model">stock.picking</field>
+        <field name="report_type">qweb-text</field>
+        <field
+            name="report_name"
+        >impress_stock_customizations.zpl_online_sales_content</field>
+        <field
+            name="report_file"
+        >impress_stock_customizations.zpl_online_sales_content</field>
+        <field
+            name="print_report_name"
+        >'ZPL Online Sales Content - %s - %s' % (object.partner_id.name or '', object.origin)</field>
+        <field name="binding_model_id" ref="stock.model_stock_picking" />
+        <field name="binding_type">report</field>
+    </record>
 </odoo>


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added conditional rendering for minimum_shelf_life field using t-if attribute

- Reformatted XML attributes for improved readability and consistency

- Removed commented-out duplicate barcode record definition

- Fixed indentation and whitespace formatting throughout the file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["XML Report Template"] -->|Add conditional check| B["minimum_shelf_life field"]
  A -->|Reformat attributes| C["Improved readability"]
  A -->|Remove duplicates| D["Cleaned code"]
  B -->|t-if condition| E["Field only displays if exists"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>impress_stock_customizations_stock_delivery_document_views.xml</strong><dd><code>Add conditional rendering and reformat XML structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

impress_stock_customizations/reports/impress_stock_customizations_stock_delivery_document_views.xml

<ul><li>Added <code>t-if="o.fields_get().get('x_minimum_shelf_life', False)"</code> <br>condition to minimum_shelf_life div to prevent display errors when <br>field doesn't exist<br> <li> Reformatted multiple XML field and xpath elements with attributes on <br>separate lines for better readability<br> <li> Removed commented-out duplicate barcode record definition<br> <li> Fixed indentation and whitespace consistency throughout the file</ul>


</details>


  </td>
  <td><a href="https://github.com/Impress-Foods/impress-odoo/pull/194/files#diff-b99398094e898616ca0d4607e7770e69133d74b8838a827a4dbafd180551339e">+25/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

