### PR TITLE
[19.0][FIX] FIxed position of shipping_date field to main section in sale order

### DIFF
--- a/impress_sales_customizations/views/sale_order_views.xml
+++ b/impress_sales_customizations/views/sale_order_views.xml
@@ -77,7 +77,7 @@
         <field name="model">sale.order</field>
         <field name="priority">100</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='delivery_status']" position="after">
+            <xpath expr="//field[@name='partner_shipping_id']" position="after">
                 <xpath
                     expr="//group[@name='sale_shipping']//label[1]"
                     position="move"


### PR DESCRIPTION
Signed-off-by: Cédric Paradis <cedric@cedricparadis.ca>